### PR TITLE
HBSD: Fix build of openjdks

### DIFF
--- a/java/bootstrap-openjdk17/Makefile
+++ b/java/bootstrap-openjdk17/Makefile
@@ -16,8 +16,8 @@ ONLY_FOR_ARCHS=	aarch64 amd64 i386 powerpc64 powerpc64le
 
 USES=		tar:xz
 
-MPROTECT_DISABLE=	bootstrap-openjdk11/bin/java
-PAGEEXEC_DISABLE=	bootstrap-openjdk11/bin/java
+MPROTECT_DISABLE=	bootstrap-openjdk17/bin/java
+PAGEEXEC_DISABLE=	bootstrap-openjdk17/bin/java
 
 NO_BUILD=	yes
 PLIST_SUB=	JDK_ROOT=${JDK_ROOT}

--- a/java/bootstrap-openjdk8/Makefile
+++ b/java/bootstrap-openjdk8/Makefile
@@ -33,8 +33,8 @@ PLIST_SUB=	JDK_ARCH=${JDK_ARCH} JDK_ROOT=${JDK_ROOT}
 USES=		tar:xz
 WRKSRC=		${WRKDIR}/${JDK_ROOT}
 
-MPROTECT_DISABLE=	bootstrap-openjdk11/bin/java
-PAGEEXEC_DISABLE=	bootstrap-openjdk11/bin/java
+MPROTECT_DISABLE=	bootstrap-openjdk8/bin/java
+PAGEEXEC_DISABLE=	bootstrap-openjdk8/bin/java
 
 INSTALLDIR=	${STAGEDIR}${PREFIX}/${JDK_ROOT}
 

--- a/java/openjdk8/Makefile
+++ b/java/openjdk8/Makefile
@@ -262,8 +262,7 @@ CONFIGURE_ARGS+=	--disable-freetype-bundling \
 			--with-jvm-variants=${JDK_BUILD_JVM} \
 			--with-milestone=fcs \
 			--with-package-path=${LOCALBASE} \
-			--with-zlib=system \
-			--with-extra-ldflags="-Wl,--undefined-version"
+			--with-zlib=system
 CONFIGURE_SCRIPT=	../../configure
 CONFIGURE_WRKSRC=	${WRKSRC}/common/autoconf
 
@@ -385,7 +384,7 @@ MAKE_ENV+=	COMPILER_WARNINGS_FATAL=false USE_CLANG=true
 CONFIGURE_ENV+=	LIBCXX="-lc++"
 CONFIGURE_ARGS+=	--with-extra-cflags="-Wno-unused-but-set-parameter -Wno-bitwise-instead-of-logical"
 CONFIGURE_ARGS+=	--with-extra-cxxflags="-Wno-unused-but-set-parameter -Wno-bitwise-instead-of-logical"
-CONFIGURE_ARGS+=	--with-extra-ldflags="-Wno-error=unused-command-line-argument"
+CONFIGURE_ARGS+=	--with-extra-ldflags="-Wno-error=unused-command-line-argument -Wl,--undefined-version"
 .if ${COMPILER_VERSION} >= 130 && ${ARCH} == aarch64
 # PR258954: see <https://bugs.openjdk.org/browse/JDK-8247766>. Even though the
 # upstream fix has been applied to this version of the JDK, users still report


### PR DESCRIPTION
### Fixed
- [OPENJDK] Ignored with-extra-ldflags with llvm17